### PR TITLE
Add minimal Feedly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# mcp_server_feedly
+# MCP Server for Feedly API
+
+This repository contains a minimal [FastMCP](https://github.com/jlowin/fastmcp) server that exposes selected Feedly API endpoints as MCP tools. The server provides the following tools:
+
+- `feedly.search`
+- `feedly.collect`
+- `feedly.entity_lookup`
+- `feedly.autocomplete`
+
+These tools make it possible for MCP-aware language models to search and retrieve articles or NLP entity information from Feedly.
+
+## Setup
+
+1. Create and activate a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install fastmcp httpx python-dotenv
+```
+
+2. Export your Feedly authentication token so the server can call the Feedly API:
+
+```bash
+export FEEDLY_TOKEN=YOUR_TOKEN_HERE
+```
+
+## Running the server
+
+Run the server on port `8080`:
+
+```bash
+python server.py
+```
+
+The MCP discovery document will be available at `http://localhost:8080/.well-known/mcp/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastmcp
+httpx
+python-dotenv

--- a/server.py
+++ b/server.py
@@ -1,0 +1,70 @@
+from fastmcp import FastMCP
+import httpx
+import os
+from urllib.parse import quote_plus
+
+mcp = FastMCP("feedly")
+
+FEEDLY_BASE = "https://api.feedly.com/v3"
+TOKEN = os.getenv("FEEDLY_TOKEN")
+
+HEADERS = {
+    "Authorization": f"Bearer {TOKEN}",
+    "accept": "application/json",
+}
+
+@mcp.tool(name="feedly.search",
+          description="Full-text or NLP Layer search against Feedly work-space")
+def search(query: str, count: int = 10) -> dict:
+    """Return up to `count` articles that match the query."""
+    params = {"count": str(count)}
+    body = {"query": query}
+    resp = httpx.post(f"{FEEDLY_BASE}/search/contents",
+                       params=params, json=body, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+@mcp.tool(name="feedly.collect",
+          description="Fetch articles from a Feedly StreamID (team feed, board, …)")
+def collect(stream_id: str,
+            count: int = 20,
+            continuation: str | None = None) -> dict:
+    """StreamID example: enterprise/feedly/category/f74cc0…"""
+    params = {"streamId": stream_id, "count": str(count)}
+    if continuation:
+        params["continuation"] = continuation
+    resp = httpx.get(f"{FEEDLY_BASE}/streams/contents",
+                     params=params, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+# --- NEW TOOLS ---------------------------------------------------------------
+@mcp.tool(name="feedly.entity_lookup",
+          description="Return metadata about a single NLP entity ID.")
+def entity_lookup(entity_id: str) -> dict:
+    """
+    Look up a Feedly NLP entity by ID (example:
+    'nlp/f/entity/gz:org:apple').  URL-encode the ID automatically.
+    """
+    encoded = quote_plus(entity_id)
+    resp = httpx.get(f"{FEEDLY_BASE}/entities/{encoded}",
+                     headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+@mcp.tool(name="feedly.autocomplete",
+          description="Suggest entity IDs that match a text prefix.")
+def autocomplete_entities(prefix: str, count: int = 10) -> dict:
+    """
+    Autocomplete Feedly NLP entities.  Typical use: user types "Nvid"
+    → get entity ID for Nvidia Corporation.
+    """
+    params = {"prefix": prefix, "count": str(count)}
+    resp = httpx.get(f"{FEEDLY_BASE}/entities/autocomplete",
+                     params=params, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    mcp.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
- add minimal Feedly MCP server with four tools using FastMCP
- document setup and usage in README
- add requirements file

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb1eed9708332bb565493f35c596a