### PR TITLE
Fix server startup with FastMCP 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ export FEEDLY_TOKEN=YOUR_TOKEN_HERE
 
 ## Running the server
 
-Run the server on port `8080`:
+Run the server over HTTP on port `8080`:
 
 ```bash
 python server.py

--- a/server.py
+++ b/server.py
@@ -67,4 +67,5 @@ def autocomplete_entities(prefix: str, count: int = 10) -> dict:
 # -----------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    mcp.run(host="0.0.0.0", port=8080)
+    # Run the MCP server over HTTP rather than the default stdio transport
+    mcp.run(transport="streamable-http", host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
- ensure `server.py` uses HTTP transport when running FastMCP
- clarify README about HTTP server

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fcc1ac0408332b2c353b5a3557bba