### PR TITLE
docs: rename FastMCP reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Server for Feedly API
 
-This repository contains a minimal [FastMCP](https://github.com/jlowin/fastmcp) server that exposes selected Feedly API endpoints as MCP tools. The server provides the following tools:
+This repository contains a minimal [python-sdk](https://github.com/modelcontextprotocol/python-sdk) server that exposes selected Feedly API endpoints as MCP tools. The server provides the following tools:
 
 - `feedly.search`
 - `feedly.collect`
@@ -16,7 +16,7 @@ These tools make it possible for MCP-aware language models to search and retriev
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install fastmcp httpx python-dotenv
+pip install mcp httpx python-dotenv
 ```
 
 2. Export your Feedly authentication token so the server can call the Feedly API:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fastmcp
+mcp
 httpx
 python-dotenv

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-from fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP
 import httpx
 import os
 from urllib.parse import quote_plus


### PR DESCRIPTION
## Summary
- rename `FastMCP` mention in README
- switch repository URL to official python-sdk repo
- migrate package name to `mcp` for examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fcfb1a1e48332b6d2ea0f79c8e548