### PR TITLE
Add Claude Desktop config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ python server.py
 ```
 
 The MCP discovery document will be available at `http://localhost:8080/.well-known/mcp/`.
+
+## Using with Claude Desktop
+
+To connect Claude Desktop directly to this server, open **File > Settings > Developer > Edit Config** and
+create or update `claude_desktop_config.json` with an entry like:
+
+```json
+{
+  "mcpServers": {
+    "feedly": {
+      "command": "python",
+      "args": [
+        "/path/to/mcp_server_feedly/server.py"
+      ]
+    }
+  }
+}
+```
+
+Replace the path with the location of `server.py` on your system. Claude Desktop will use this command to start the Feedly MCP server when needed.


### PR DESCRIPTION
## Summary
- document how to configure Claude Desktop

## Testing
- `python -m pip install -r requirements.txt`
- `python server.py` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_683ff1e276508332a071e23d1ffb0d13