### PR TITLE
Add client utility and server test

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,20 @@
+import anyio
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+async def run(url: str, tool: str, args: dict[str, object] | None = None) -> None:
+    async with streamablehttp_client(url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool, args)
+            print(result.model_dump())
+
+if __name__ == "__main__":
+    import argparse, json
+
+    parser = argparse.ArgumentParser(description="Call a tool on the Feedly MCP server")
+    parser.add_argument("tool", help="Tool name to invoke")
+    parser.add_argument("--url", default="http://localhost:8080", help="Server base URL")
+    parser.add_argument("--args", type=json.loads, default="{}", help="Tool arguments as JSON")
+    opts = parser.parse_args()
+    anyio.run(run, opts.url, opts.tool, opts.args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 mcp
 httpx
 python-dotenv
+pytest
+trio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,37 @@
+import subprocess
+import time
+import anyio
+import pytest
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+@pytest.fixture(scope="module")
+def server_proc():
+    proc = subprocess.Popen(["python", "server.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # wait for server to start
+    for _ in range(20):
+        try:
+            import socket
+            with socket.create_connection(("localhost", 8080), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.5)
+    else:
+        proc.terminate()
+        proc.wait()
+        raise RuntimeError("server did not start")
+    yield proc
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_tools(server_proc):
+    async with streamablehttp_client("http://localhost:8080/mcp") as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            names = [t.name for t in result.tools]
+            assert "feedly.search" in names


### PR DESCRIPTION
## Summary
- create a simple MCP client script
- add pytest-based server test
- include pytest and trio in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842532b37c48332b6d342778887ad53