### PR TITLE
Add Claude Desktop config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ create or update `claude_desktop_config.json` with an entry like:
 {
   "mcpServers": {
     "feedly": {
+      "url": "http://localhost:8080/mcp",
       "command": "npx",
       "args": [
         "ts-node",
@@ -55,4 +56,6 @@ create or update `claude_desktop_config.json` with an entry like:
 }
 ```
 
-Replace the path with the location of `server.ts` on your system and supply your Feedly token in place of `YOUR_TOKEN_HERE`. Claude Desktop will use this command to start the Feedly MCP server when needed.
+`url` tells Claude Desktop where to reach the server. `command` and `args` allow the app to start it automatically. Replace the path with the location of `server.ts` on your system and set `FEEDLY_TOKEN` to your Feedly token.
+
+You can copy `claude_desktop_config.example.json` from this repository as a starting point.

--- a/claude_desktop_config.example.json
+++ b/claude_desktop_config.example.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "feedly": {
+      "url": "http://localhost:8080/mcp",
+      "command": "npx",
+      "args": [
+        "ts-node",
+        "<path>/server.ts"
+      ],
+      "env": {
+        "FEEDLY_TOKEN": "YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document how to configure Claude Desktop with a URL
- provide `claude_desktop_config.example.json` as a template

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anyio')*

------
https://chatgpt.com/codex/tasks/task_e_6842596713b88332bed8646ad5582039