### PR TITLE
Add config enable/transport guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ create or update `claude_desktop_config.json` with an entry like:
 {
   "mcpServers": {
     "feedly": {
+      "transport": "http",
+      "enabled": true,
+      "url": "http://localhost:8080/mcp",
       "command": "npx",
       "args": [
         "ts-node",
@@ -55,4 +58,17 @@ create or update `claude_desktop_config.json` with an entry like:
 }
 ```
 
-Replace the path with the location of `server.ts` on your system and supply your Feedly token in place of `YOUR_TOKEN_HERE`. Claude Desktop will use this command to start the Feedly MCP server when needed.
+`url` tells Claude Desktop where to reach the server. `command` and `args` allow the app to start it automatically. Replace the path with the location of `server.ts` on your system and set `FEEDLY_TOKEN` to your Feedly token.
+
+You can copy `claude_desktop_config.example.json` from this repository as a starting point.
+
+## Running tests
+
+Install the Python dependencies and run the test suite:
+
+```bash
+pip install -r requirements.txt
+FEEDLY_TOKEN=fe_ljAZpFmvUJelhS61UBoKD2PzLkHi6fZupywpzlGz pytest -q
+```
+
+These tests compile the TypeScript server and verify that the MCP discovery endpoint responds correctly.

--- a/claude_desktop_config.example.json
+++ b/claude_desktop_config.example.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "feedly": {
+      "transport": "http",
+      "enabled": true,
+      "url": "http://localhost:8080/mcp",
+      "command": "npx",
+      "args": [
+        "ts-node",
+        "<path>/server.ts"
+      ],
+      "env": {
+        "FEEDLY_TOKEN": "YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+anyio
+mcp


### PR DESCRIPTION
## Summary
- improve Claude Desktop configuration with transport and enabled flags
- document running tests and add requirements.txt

## Testing
- `npm test` *(fails: Error: no test specified)*
- `FEEDLY_TOKEN=fe_ljAZpFmvUJelhS61UBoKD2PzLkHi6fZupywpzlGz pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842596713b88332bed8646ad5582039