### PR TITLE
Fix express named import with ts-node

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,5 @@
-import express, { Request, Response } from 'express';
+import express from 'express';
+import type { Request, Response } from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { z } from 'zod';


### PR DESCRIPTION
## Summary
- fix express import in TypeScript to avoid runtime error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427059c5d88332a597b1db7a9a06f0