### PR TITLE
Make server port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ export FEEDLY_TOKEN=YOUR_TOKEN_HERE
 
 ## Running the server
 
-Run the server over HTTP on port `8080`:
+Run the server over HTTP on port `8080` by default:
 
 ```bash
 npx ts-node server.ts
+```
+
+You can override the port by setting the `PORT` environment variable:
+
+```bash
+PORT=8081 npx ts-node server.ts
 ```
 
 The MCP discovery document will be available at `http://localhost:8080/.well-known/mcp/`.
@@ -51,14 +57,15 @@ create or update `claude_desktop_config.json` with an entry like:
         "/path/to/mcp_server_feedly/server.ts"
       ],
       "env": {
-        "FEEDLY_TOKEN": "YOUR_TOKEN_HERE"
+        "FEEDLY_TOKEN": "YOUR_TOKEN_HERE",
+        "PORT": "8081"
       }
     }
   }
 }
 ```
 
-`url` tells Claude Desktop where to reach the server. `command` and `args` allow the app to start it automatically. Replace the path with the location of `server.ts` on your system and set `FEEDLY_TOKEN` to your Feedly token.
+`url` tells Claude Desktop where to reach the server. `command` and `args` allow the app to start it automatically. Replace the path with the location of `server.ts` on your system and set `FEEDLY_TOKEN` to your Feedly token. Set `PORT` if you want the server to listen on something other than `8080` and update `url` accordingly.
 
 You can copy `claude_desktop_config.example.json` from this repository as a starting point.
 

--- a/claude_desktop_config.example.json
+++ b/claude_desktop_config.example.json
@@ -3,14 +3,15 @@
     "feedly": {
       "transport": "http",
       "enabled": true,
-      "url": "http://localhost:8080/mcp",
+      "url": "http://localhost:8081/mcp",
       "command": "npx",
       "args": [
         "ts-node",
         "<path>/server.ts"
       ],
       "env": {
-        "FEEDLY_TOKEN": "YOUR_TOKEN_HERE"
+        "FEEDLY_TOKEN": "YOUR_TOKEN_HERE",
+        "PORT": "8081"
       }
     }
   }

--- a/server.ts
+++ b/server.ts
@@ -114,5 +114,5 @@ app.delete('/mcp', (_req: Request, res: Response) => {
   });
 });
 
-const PORT = 8080;
+const PORT = parseInt(process.env.PORT || '8080', 10);
 app.listen(PORT, '0.0.0.0');


### PR DESCRIPTION
## Summary
- read server port from `PORT` env var
- document port customization in README and example config

## Testing
- `npm install`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842733bb5c08332a6a0199e0e337a2c