### PR TITLE
Fix config port mismatch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ create or update `claude_desktop_config.json` with an entry like:
     "feedly": {
       "transport": "http",
       "enabled": true,
-      "url": "http://localhost:8080/mcp",
+      "url": "http://localhost:8081/mcp",
       "command": "npx",
       "args": [
         "ts-node",


### PR DESCRIPTION
## Summary
- fix port mismatch in README example config so the url matches the PORT env variable

## Testing
- `npm test` *(fails: no test specified)*
- `FEEDLY_TOKEN=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842788b01788332999a6d4e3ce79b9a